### PR TITLE
Junit5 extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,8 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk8
-  - openjdk7
 env:
   - WELD_PROFILE=weld2
   - WELD_PROFILE=weld3
-matrix:
-  exclude:
-    - jdk: openjdk7
-      env: WELD_PROFILE=weld3
 script: "mvn verify -P${WELD_PROFILE}"
 sudo: false

--- a/junit-common/.gitignore
+++ b/junit-common/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.settings/
+/.classpath
+/.project

--- a/junit-common/pom.xml
+++ b/junit-common/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-junit-parent</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>weld-junit-common</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/junit-common/pom.xml
+++ b/junit-common/pom.xml
@@ -9,11 +9,6 @@
     <artifactId>weld-junit-common</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.weld.se</groupId>

--- a/junit-common/src/main/java/org/jboss/weld/junit/AbstractWeldInitiator.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/AbstractWeldInitiator.java
@@ -1,0 +1,378 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.NormalScope;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.util.TypeLiteral;
+
+import org.jboss.weld.config.ConfigurationKey;
+import org.jboss.weld.environment.ContainerInstance;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.inject.WeldInstance;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public abstract class AbstractWeldInitiator implements WeldInstance<Object>, ContainerInstance {
+
+    /**
+     * The returned {@link Weld} instance has:
+     * <ul>
+     * <li>automatic discovery disabled</li>
+     * <li>concurrent deployment disabled</li>
+     * </ul>
+     *
+     * @return a new {@link Weld} instance suitable for testing
+     */
+    public static Weld createWeld() {
+        return new Weld().disableDiscovery().property(ConfigurationKey.CONCURRENT_DEPLOYMENT.get(),
+            false);
+    }
+
+    protected final Weld weld;
+
+    protected final List<ToInject> instancesToInject;
+
+    protected final Set<Class<? extends Annotation>> scopesToActivate;
+
+    protected final Set<Bean<?>> beans;
+
+    protected final WeldCDIExtension extension;
+
+    protected volatile WeldContainer container;
+
+    protected AbstractWeldInitiator(Weld weld, List<Object> instancesToInject,
+        Set<Class<? extends Annotation>> scopesToActivate, Set<Bean<?>> beans) {
+        this.instancesToInject = new ArrayList<>();
+        for (Object instance : instancesToInject) {
+            this.instancesToInject.add(createToInject(instance));
+        }
+        this.scopesToActivate = scopesToActivate;
+        this.beans = beans;
+        this.weld = weld;
+        if (hasScopesToActivate() || hasBeansToAdd()) {
+            this.extension = new WeldCDIExtension(this.scopesToActivate, this.beans);
+            this.weld.addExtension(this.extension);
+        } else {
+            this.extension = null;
+        }
+    }
+
+    protected ToInject createToInject(Object instanceToInject) {
+        return new ToInject(instanceToInject);
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        checkContainer();
+        return container.iterator();
+    }
+
+    @Override
+    public Object get() {
+        checkContainer();
+        return container.get();
+    }
+
+    @Override
+    public WeldInstance<Object> select(Annotation... qualifiers) {
+        checkContainer();
+        return container.select(qualifiers);
+    }
+
+    @Override
+    public <U> WeldInstance<U> select(Class<U> subtype, Annotation... qualifiers) {
+        checkContainer();
+        return container.select(subtype, qualifiers);
+    }
+
+    @Override
+    public <U> WeldInstance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+        checkContainer();
+        return container.select(subtype, qualifiers);
+    }
+
+    @Override
+    public boolean isUnsatisfied() {
+        checkContainer();
+        return container.isUnsatisfied();
+    }
+
+    @Override
+    public boolean isAmbiguous() {
+        checkContainer();
+        return container.isAmbiguous();
+    }
+
+    @Override
+    public Handler<Object> getHandler() {
+        checkContainer();
+        return container.getHandler();
+    }
+
+    @Override
+    public boolean isResolvable() {
+        checkContainer();
+        return container.isResolvable();
+    }
+
+    @Override
+    public Iterable<Handler<Object>> handlers() {
+        checkContainer();
+        return container.handlers();
+    }
+
+    @Override
+    public void destroy(Object instance) {
+        checkContainer();
+        container.destroy(instance);
+    }
+
+    /**
+     * Allows to fire events.
+     *
+     * @return an event object
+     */
+    public Event<Object> event() {
+        checkContainer();
+        return container.event();
+    }
+
+    @Override
+    public BeanManager getBeanManager() {
+        checkContainer();
+        return container.getBeanManager();
+    }
+
+    @Override
+    public String getId() {
+        return container.getId();
+    }
+
+    /**
+     * Note that any container-based operation will result in {@link IllegalStateException} after shutdown.
+     */
+    @Override
+    public void shutdown() {
+        container.shutdown();
+    }
+
+    /**
+     *
+     * @return <code>true</code> if the container was initialized completely and is not shut down yet, <code>false</code>
+     *         otherwise
+     */
+    public boolean isRunning() {
+        return container.isRunning();
+    }
+
+    private void checkContainer() {
+        if (container == null || !container.isRunning()) {
+            throw new IllegalStateException("Weld container is not running");
+        }
+    }
+
+    protected void injectInstances() {
+        if (instancesToInject != null) {
+            for (ToInject toInject : instancesToInject) {
+                toInject.inject();
+            }
+        }
+    }
+
+    protected void releaseInstances() {
+        if (instancesToInject != null) {
+            for (ToInject toInject : instancesToInject) {
+                toInject.release();
+            }
+        }
+    }
+
+    private boolean hasScopesToActivate() {
+        return scopesToActivate != null && !scopesToActivate.isEmpty();
+    }
+
+    private boolean hasBeansToAdd() {
+        return beans != null && !beans.isEmpty();
+    }
+
+    protected class ToInject {
+
+        private final Object instance;
+
+        private volatile CreationalContext<?> creationalContext;
+
+        ToInject(Object instance) {
+            this.instance = instance;
+        }
+
+        void inject() {
+            BeanManager beanManager = container.getBeanManager();
+            CreationalContext<Object> ctx = beanManager.createCreationalContext(null);
+            @SuppressWarnings("unchecked")
+            InjectionTarget<Object> injectionTarget = (InjectionTarget<Object>) beanManager
+                .getInjectionTargetFactory(beanManager.createAnnotatedType(instance.getClass()))
+                .createInjectionTarget(null);
+            injectionTarget.inject(instance, ctx);
+            creationalContext = ctx;
+        }
+
+        void release() {
+            if (creationalContext != null) {
+                creationalContext.release();
+            }
+        }
+
+    }
+
+    protected static abstract class AbstractBuilder {
+
+        protected final Weld weld;
+
+        protected final List<Object> instancesToInject;
+
+        protected final Set<Class<? extends Annotation>> scopesToActivate;
+
+        protected final Set<Bean<?>> beans;
+
+        public AbstractBuilder(Weld weld) {
+            this.weld = weld;
+            this.instancesToInject = new ArrayList<>();
+            this.scopesToActivate = new HashSet<>();
+            this.beans = new HashSet<>();
+        }
+
+        /**
+         * Activate and deactivate contexts for the given normal scopes for each test method execution.
+         * <p>
+         * {@link ApplicationScoped} is ignored as it is always active.
+         * </p>
+         *
+         * @param normalScopes
+         * @return self
+         */
+        public AbstractBuilder activate(Class<? extends Annotation>... normalScopes) {
+            for (Class<? extends Annotation> scope : normalScopes) {
+                if (ApplicationScoped.class.equals(scope)) {
+                    continue;
+                }
+                if (!scope.isAnnotationPresent(NormalScope.class)) {
+                    throw new IllegalArgumentException(
+                        "Only annotations annotated with @NormalScope are supported!");
+                }
+                this.scopesToActivate.add(scope);
+            }
+            return this;
+        }
+
+        /**
+         * Instructs the {@link WeldInitiator} to inject the given non-contextual instance once the container is started, i.e.
+         * during test execution.
+         *
+         * <p>
+         * This method could be used e.g. to inject a test class instance:
+         * </p>
+         *
+         * <pre>
+         * public class InjectTest {
+         *
+         *     &#64;Rule
+         *     public WeldInitiator weld = WeldInitiator.fromTestPackage().inject(this).build();
+         *
+         *     &#64;Inject
+         *     Foo foo;
+         *
+         *     &#64;Test
+         *     public void testFoo() {
+         *         assertEquals("foo", foo.getId());
+         *     }
+         * }
+         * </pre>
+         *
+         * <p>
+         * Injected {@link Dependent} bean instances are destroyed after the test execution. However, the licecycle of the
+         * non-contextual instance is not managed by the container and all injected references will be invalid after the test
+         * execution.
+         * </p>
+         *
+         * @param instance
+         * @return self
+         */
+        public AbstractBuilder inject(Object instance) {
+            this.instancesToInject.add(instance);
+            return this;
+        }
+
+        /**
+         * Instructs the {@link WeldInitiator} to add the specified beans during {@link AfterBeanDiscovery} notification.
+         *
+         * @param beans
+         * @return self
+         * @see AfterBeanDiscovery#addBean(Bean)
+         * @since 1.1
+         */
+        public AbstractBuilder addBeans(Bean<?>... beans) {
+            Collections.addAll(this.beans, beans);
+            return this;
+        }
+
+        /**
+         *
+         * @return a new {@link WeldInitiator} instance
+         */
+        public abstract AbstractWeldInitiator build();
+
+    }
+
+    protected WeldContainer initWeldContainer(Weld weld) {
+        container = weld.initialize();
+        injectInstances();
+        if (extension != null) {
+            extension.activateContexts();
+        }
+        return container;
+    }
+
+    protected void shutdownWeldContainer() {
+        try {
+            if (extension != null) {
+                extension.deactivateContexts();
+            }
+            releaseInstances();
+        } finally {
+            if (container != null && container.isRunning()) {
+                container.shutdown();
+            }
+        }
+    }
+}

--- a/junit-common/src/main/java/org/jboss/weld/junit/ContextImpl.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/ContextImpl.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.weld.junit4;
+package org.jboss.weld.junit;
 
 import java.lang.annotation.Annotation;
 import java.util.HashMap;

--- a/junit-common/src/main/java/org/jboss/weld/junit/MockBean.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/MockBean.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.weld.junit4;
+package org.jboss.weld.junit;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -130,7 +130,7 @@ public class MockBean<T> implements Bean<T>, PassivationCapable {
 
     @Override
     public Class<?> getBeanClass() {
-        return WeldJunit4Extension.class;
+        return WeldCDIExtension.class;
     }
 
     @Override

--- a/junit-common/src/main/java/org/jboss/weld/junit/WeldCDIExtension.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/WeldCDIExtension.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.weld.junit4;
+package org.jboss.weld.junit;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -29,8 +29,9 @@ import javax.enterprise.inject.spi.Extension;
 /**
  *
  * @author Martin Kouba
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
  */
-class WeldJunit4Extension implements Extension {
+class WeldCDIExtension implements Extension {
 
     private final Set<Class<? extends Annotation>> scopesToActivate;
 
@@ -38,7 +39,7 @@ class WeldJunit4Extension implements Extension {
 
     private final List<ContextImpl> contexts;
 
-    WeldJunit4Extension(Set<Class<? extends Annotation>> scopesToActivate, Set<Bean<?>> beans) {
+    public WeldCDIExtension(Set<Class<? extends Annotation>> scopesToActivate, Set<Bean<?>> beans) {
         this.scopesToActivate = scopesToActivate;
         this.beans = beans;
         this.contexts = new ArrayList<>();
@@ -59,7 +60,7 @@ class WeldJunit4Extension implements Extension {
         }
     }
 
-    void activateContexts() {
+    public void activateContexts() {
         if (contexts.isEmpty()) {
             return;
         }
@@ -68,7 +69,7 @@ class WeldJunit4Extension implements Extension {
         }
     }
 
-    void deactivateContexts() {
+    public void deactivateContexts() {
         if (contexts.isEmpty()) {
             return;
         }
@@ -76,5 +77,4 @@ class WeldJunit4Extension implements Extension {
             context.deactivate();
         }
     }
-
 }

--- a/junit4/pom.xml
+++ b/junit4/pom.xml
@@ -17,6 +17,11 @@
       </dependency>
 
       <dependency>
+          <groupId>org.jboss.weld</groupId>
+          <artifactId>weld-junit-common</artifactId>
+      </dependency>
+      
+      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
       </dependency>

--- a/junit4/src/main/java/org/jboss/weld/junit4/WeldInitiator.java
+++ b/junit4/src/main/java/org/jboss/weld/junit4/WeldInitiator.java
@@ -17,39 +17,33 @@
 package org.jboss.weld.junit4;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Bean;
 
-import org.jboss.weld.environment.ContainerInstance;
 import org.jboss.weld.environment.se.Weld;
-import org.jboss.weld.inject.WeldInstance;
 import org.jboss.weld.junit.AbstractWeldInitiator;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
- * Test rule which starts a Weld container per each test method execution:
+ * JUnit 4 initiator - test rule which starts a Weld container per each test method execution:
  *
  * <pre>
  * public class SimpleTest {
  *
- *     &#64;Rule
- * public WeldInitiator weld = WeldInitiator.of(Foo.class);
+ *    &#64;Rule
+ *    public WeldInitiator weld = WeldInitiator.of(Foo.class);
  *
- * &#64;Test
- * public void testFoo() {
- * // Weld container is started automatically
- * // WeldInitiator can be used to perform programmatic lookup of beans
- * assertEquals("baz", weld.select(Foo.class).get().getBaz());
- * }
+ *    &#64;Test
+ *    public void testFoo() {
+ *       // Weld container is started automatically
+ *       // WeldInitiator can be used to perform programmatic lookup of beans
+ *       assertEquals("baz", weld.select(Foo.class).get().getBaz());
+ *    }
  * }
  * </pre>
  *
@@ -61,7 +55,7 @@ import org.junit.runners.model.Statement;
  * @author Martin Kouba
  * @author Matej Novotny
  */
-public class WeldInitiator extends AbstractWeldInitiator implements TestRule, WeldInstance<Object>, ContainerInstance {
+public class WeldInitiator extends AbstractWeldInitiator implements TestRule {
 
     /**
      * The container is configured with the result of {@link #createWeld()} method and the given bean classes are added.
@@ -127,50 +121,22 @@ public class WeldInitiator extends AbstractWeldInitiator implements TestRule, We
     }
 
     /**
-     * This builder can be used to customize the final {@link WeldInitiator} instance, e.g. to activate a context for a given
-     * normal scope.
+     * This builder can be used to customize the final {@link WeldInitiator} instance, e.g. to activate a context for a given normal scope.
      */
-    public static final class Builder extends AbstractBuilder {
+    public static final class Builder extends AbstractBuilder<WeldInitiator, Builder> {
 
-        public Builder(Weld weld) {
+        private Builder(Weld weld) {
             super(weld);
         }
 
-        /**
-         * Activate and deactivate contexts for the given normal scopes for each test method execution.
-         * <p>
-         * {@link ApplicationScoped} is ignored as it is always active.
-         * </p>
-         *
-         * @param normalScopes
-         * @return self
-         */
-        @SafeVarargs
-        public final Builder activate(Class<? extends Annotation>... normalScopes) {
-            return (Builder) super.activate(normalScopes);
-        }
-
-        public Builder inject(Object instance) {
-            return (Builder) super.inject(instance);
-        }
-
-        public Builder addBeans(Bean<?>... beans) {
-            return (Builder) super.addBeans(beans);
-        }
-
-        /**
-         *
-         * @return a new {@link WeldInitiator} instance
-         */
         @Override
-        public WeldInitiator build() {
-            return new WeldInitiator(weld,
-                instancesToInject.isEmpty() ? Collections.emptyList()
-                    : new ArrayList<>(instancesToInject),
-                scopesToActivate.isEmpty()
-                    ? Collections.<Class<? extends Annotation>>emptySet()
-                    : new HashSet<>(scopesToActivate),
-                beans.isEmpty() ? Collections.<Bean<?>>emptySet() : new HashSet<>(beans));
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        protected WeldInitiator build(Weld weld, List<Object> instancesToInject, Set<Class<? extends Annotation>> scopesToActivate, Set<Bean<?>> beans) {
+            return new WeldInitiator(weld, instancesToInject, scopesToActivate, beans);
         }
 
     }

--- a/junit4/src/test/java/org/jboss/weld/junit4/bean/AddBeanTest.java
+++ b/junit4/src/test/java/org/jboss/weld/junit4/bean/AddBeanTest.java
@@ -31,8 +31,8 @@ import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.util.TypeLiteral;
 
-import org.jboss.weld.junit4.MockBean;
-import org.jboss.weld.junit4.MockBean.CreateFunction;
+import org.jboss.weld.junit.MockBean;
+import org.jboss.weld.junit.MockBean.CreateFunction;
 import org.jboss.weld.junit4.WeldInitiator;
 import org.junit.Rule;
 import org.junit.Test;

--- a/junit5/.gitignore
+++ b/junit5/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/.settings/
+/.classpath
+/.project

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-junit-parent</artifactId>
         <version>1.1.1-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>weld-junit5</artifactId>
-    
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -20,7 +20,7 @@
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-junit-common</artifactId>
@@ -35,14 +35,14 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
-        
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -54,7 +54,7 @@
                         <dependency>
                             <groupId>org.junit.platform</groupId>
                             <artifactId>junit-platform-surefire-provider</artifactId>
-                            <version>${junit.platform.version}</version>
+                            <version>${version.junit.platform}</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -10,10 +10,6 @@
 
     <artifactId>weld-junit5</artifactId>
 
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
     <dependencies>
 
         <dependency>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-junit-parent</artifactId>
+        <version>1.1.1-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>weld-junit5</artifactId>
+    
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-junit-common</artifactId>
+        </dependency>
+
+        <!--JUnit 5 dependencies-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <dependencies>
+                        <!-- Surefire doesn't know JUnit 5 provider yet, we need to add it here -->
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>${junit.platform.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
@@ -1,0 +1,176 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Qualifier;
+
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.junit.AbstractWeldInitiator;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+/**
+ * JUnit 5 extension allowing to bootstrap Weld SE container for each @Test method and tear it down afterwards. Also allows to
+ * inject CDI beans as parameters to @Test methods and resolves all @Inject fields in test class.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class WeldJunit5Extension implements AfterAllCallback, TestInstancePostProcessor, AfterTestExecutionCallback, ParameterResolver {
+
+    private static final String INITIATOR = "weldInitiator";
+    private static final String CONTAINER = "weldContainer";
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        if (determineTestLifecycle(context).equals(TestInstance.Lifecycle.PER_CLASS)) {
+            getInitiatorFromStore(context).shutdownWeld();
+        }
+        // clear all that we put into Store
+        clearStore(context);
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) throws Exception {
+        if (determineTestLifecycle(context).equals(TestInstance.Lifecycle.PER_METHOD)) {
+            getInitiatorFromStore(context).shutdownWeld();
+        }
+    }
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+
+        // obtain WeldInitiator if defined, we have to use reflections here
+        // first check if we don't alredy have WeldInitiator (in per-method lifecycle this happends where there are multiple tests)s
+        if (getInitiatorFromStore(context) == null) {
+            for (Field field : testInstance.getClass().getDeclaredFields()) {
+                if (field.isAnnotationPresent(WeldSetup.class)) {
+                    if (getInitiatorFromStore(context) != null) {
+                        // multiple fields found, throw exception
+                        throw new IllegalStateException("Multiple @WeldSetup annotated fields found, please use only one such field.");
+                    }
+                    Object fieldInstance;
+                    try {
+                        fieldInstance = field.get(testInstance);
+                    } catch (IllegalAccessException e) {
+                        // In case we cannot get to the field, we need to set accessibility as well
+                        field.setAccessible(true);
+                        fieldInstance = field.get(testInstance);
+                    }
+                    if (fieldInstance instanceof WeldInitiator) {
+                        getStore(context).put(INITIATOR, (WeldInitiator) fieldInstance);
+                    } else {
+                        // Field with other type than WeldInitiator was annotated with @WeldSetup
+                        throw new IllegalStateException("@WeldSetup annotation should only be used on a field of type WeldInitiator.");
+                    }
+                }
+            }
+        }
+
+        // WeldInitiator may still be null if user didn't specify it at all, we need to create it
+        if (getInitiatorFromStore(context) == null) {
+            getStore(context).put(INITIATOR, WeldInitiator.from(AbstractWeldInitiator.createWeld().addPackage(false, testInstance.getClass())).build());
+        }
+
+        // and finally, init Weld
+        getStore(context).put(CONTAINER, getInitiatorFromStore(context).initWeld(testInstance));
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        // see if container is up, if not, we do not support it
+        if (getContainerFromStore(extensionContext) != null) {
+            List<Annotation> qualifiers = resolveQualifiers(parameterContext);
+            return getContainerFromStore(extensionContext).select(parameterContext.getParameter().getType(), qualifiers.toArray(new Annotation[qualifiers.size()])).get();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        // see if container is up, if not, we do not support it
+        if (getContainerFromStore(extensionContext) != null) {
+            List<Annotation> qualifiers = resolveQualifiers(parameterContext);
+            if (getContainerFromStore(extensionContext).select(parameterContext.getParameter().getType(), qualifiers.toArray(new Annotation[qualifiers.size()])).isResolvable()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<Annotation> resolveQualifiers(ParameterContext pc) {
+        List<Annotation> qualifiers = new ArrayList<>();
+        if (pc.getParameter().getAnnotations().length == 0) {
+            return Collections.emptyList();
+        } else {
+            for (Annotation annotation : pc.getParameter().getAnnotations()) {
+                // check if that annotation is in fact Qualifier
+                if (annotation.annotationType().isAnnotationPresent(Qualifier.class)) {
+                    qualifiers.add(annotation);
+                }
+            }
+        }
+        return qualifiers;
+    }
+
+    private TestInstance.Lifecycle determineTestLifecycle(ExtensionContext ec) {
+        // check the test for import org.junit.jupiter.api.TestInstance annotation
+        TestInstance annotation = ec.getRequiredTestClass().getAnnotation(TestInstance.class);
+        if (annotation != null) {
+            return annotation.value();
+        } else {
+            return TestInstance.Lifecycle.PER_METHOD;
+        }
+    }
+
+    /**
+     * We use custom namespace based on this extension class and test class
+     */
+    private ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestClass()));
+    }
+
+    /**
+     * Can return null if WeldInitiator isn't stored yet
+     */
+    private WeldInitiator getInitiatorFromStore(ExtensionContext context) {
+        return getStore(context).get(INITIATOR, WeldInitiator.class);
+    }
+
+    /**
+     * Can return null if WeldContainer isn't stored yet
+     */
+    private WeldContainer getContainerFromStore(ExtensionContext context) {
+        return getStore(context).get(CONTAINER, WeldContainer.class);
+    }
+    
+    private void clearStore(ExtensionContext context) {
+        getStore(context).remove(INITIATOR, WeldInitiator.class);
+        getStore(context).remove(CONTAINER, WeldContainer.class);
+    }
+}

--- a/junit5/src/main/java/org/jboss/weld/junit5/WeldSetup.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/WeldSetup.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.jboss.weld.junit5.WeldJunit5Extension;
+
+/**
+ * An annotation used to denote a WeldInitiator field. This is then picked up by {@link WeldJunit5Extension} and used for
+ * configuration.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WeldSetup {
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/BeanManagerTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/BeanManagerTest.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.basic;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class BeanManagerTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+    @Test
+    public void testFooBean() {
+        Assertions.assertEquals(1, weld.getBeanManager().getBeans(Foo.class).size());
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/ContainerNotRunningTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/ContainerNotRunningTest.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.basic;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class ContainerNotRunningTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(WeldInitiator.createWeld().beanClasses(Foo.class));
+
+    @Test
+    public void testFoo() {
+        // Shutdown container manually
+        weld.shutdown();
+        // This should throw IllegalStateException
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            weld.select(Foo.class).get();
+        });
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/CustomWeldTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/CustomWeldTest.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.basic;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class CustomWeldTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(WeldInitiator.createWeld().alternatives(FooAlternative.class).beanClasses(Foo.class, FooAlternative.class));
+
+    @Test
+    public void testFooAlternative() {
+        Assertions.assertEquals("BAZ", weld.select(Foo.class).get().getBar());
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/Foo.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/Foo.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.basic;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Foo {
+
+    private String bar;
+
+    @PostConstruct
+    public void init() {
+        bar = "baz";
+    }
+
+    public String getBar() {
+        return bar;
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/FooAlternative.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/FooAlternative.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.basic;
+
+import javax.enterprise.inject.Alternative;
+
+@Alternative
+public class FooAlternative extends Foo {
+
+    @Override
+    public String getBar() {
+        return super.getBar().toUpperCase();
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/SimpleTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/SimpleTest.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.basic;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class SimpleTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+    @Test
+    public void testFoo() {
+        Assertions.assertEquals("baz", weld.select(Foo.class).get().getBar());
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/AddBeanTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/AddBeanTest.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.util.TypeLiteral;
+
+import org.jboss.weld.junit.MockBean;
+import org.jboss.weld.junit.MockBean.CreateFunction;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class AddBeanTest {
+
+    private static final AtomicInteger SEQUENCE = new AtomicInteger(0);
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(Blue.class)
+        .addBeans(MockBean.of(Mockito.mock(MyService.class), MyService.class), createListBean(),
+            createSequenceBean(), createIdSupplierBean())
+        .build();
+
+    @SuppressWarnings("serial")
+    static Bean<?> createListBean() {
+        return MockBean.builder()
+            .types(new TypeLiteral<List<String>>() {
+            }.getType())
+            .qualifiers(Meaty.Literal.INSTANCE)
+            .creating(
+                // Mock object provided by Mockito
+                Mockito.when(Mockito.mock(List.class).get(0)).thenReturn("42").getMock())
+            .build();
+    }
+
+    static Bean<?> createSequenceBean() {
+        return MockBean.<Integer>builder()
+            .types(Integer.class)
+            .qualifiers(Meaty.Literal.INSTANCE)
+            .create((ctx) -> SEQUENCE.incrementAndGet()).build();
+//                        // We could use lambda in Java8
+//                        new CreateFunction<Integer>() {
+//                            @Override
+//                            public Integer create(CreationalContext<Integer> creationalContext) {
+//                                return SEQUENCE.incrementAndGet();
+//                            }
+//                        })
+//                .build();
+    }
+
+    static Bean<?> createIdSupplierBean() {
+        return MockBean.<IdSupplier>builder()
+            .types(IdSupplier.class)
+            .scope(ApplicationScoped.class)
+            .create(new CreateFunction<IdSupplier>() {
+                @Override
+                public IdSupplier create(CreationalContext<IdSupplier> creationalContext) {
+                    return new IdSupplier(UUID.randomUUID().toString());
+                }
+            }).build();
+    }
+
+    @Test
+    public void testBeansAdded() {
+        // Blue injects @Meaty List<String>
+        Assertions.assertEquals("42", weld.select(Blue.class).get().getStringList().get(0));
+
+        // Each Bean.create() increments the sequence
+        SEQUENCE.set(0);
+        for (int i = 1; i < 11; i++) {
+            Assertions.assertEquals(Integer.valueOf(i),
+                weld.select(Integer.class, Meaty.Literal.INSTANCE).get());
+        }
+
+        // Mock with default settings
+        MyService myService = weld.select(MyService.class).get();
+        myService.doBusiness("Adalbert");
+        Mockito.verify(myService, Mockito.atLeastOnce()).doBusiness(ArgumentMatchers.anyString());
+
+        // Test applicaction scoped bean
+        Assertions.assertEquals(weld.select(IdSupplier.class).get().getId(), weld.select(IdSupplier.class).get().getId());
+    }
+
+    interface MyService {
+
+        void doBusiness(String name);
+
+    }
+
+    static class IdSupplier {
+
+        private final String id;
+
+        public IdSupplier(String id) {
+            this.id = id;
+        }
+
+        String getId() {
+            return id;
+        }
+
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/AddPassivatingBeanTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/AddPassivatingBeanTest.java
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.weld.junit4.bean;
+package org.jboss.weld.junit5.bean;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,34 +26,40 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.util.TypeLiteral;
 
 import org.jboss.weld.junit.MockBean;
-import org.jboss.weld.junit4.WeldInitiator;
-import org.junit.Rule;
-import org.junit.Test;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  *
- * @author Martin Kouba
+ * @author Matej Novotny
  */
+@ExtendWith(WeldJunit5Extension.class)
 public class AddPassivatingBeanTest {
 
-    @Rule
+    @WeldSetup
     public WeldInitiator weld = WeldInitiator.from(List.class).addBeans(createListBean()).activate(SessionScoped.class).build();
 
     @SuppressWarnings("serial")
     static Bean<?> createListBean() {
         return MockBean.builder()
-                .types(new TypeLiteral<List<String>>() {}.getType())
-                .scope(SessionScoped.class)
-                .creating(
-                        // Mock object provided by Mockito
-                        when(mock(List.class).get(0)).thenReturn("42").getMock())
-                .build();
+            .types(new TypeLiteral<List<String>>() {
+            }.getType())
+            .scope(SessionScoped.class)
+            .creating(
+                // Mock object provided by Mockito
+                when(mock(List.class).get(0)).thenReturn("42").getMock())
+            .build();
     }
 
     @SuppressWarnings("serial")
     @Test
     public void testPassivatingBeanAdded() {
-        assertEquals("42", weld.select(new TypeLiteral<List<String>>() {}).get().get(0));
+        Assertions.assertEquals("42", weld.select(new TypeLiteral<List<String>>() {
+        }).get().get(0));
     }
 
 }

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/Blue.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/Blue.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class Blue {
+
+    @Inject
+    @Meaty
+    private List<String> stringList;
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/Meaty.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/Meaty.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+public @interface Meaty {
+
+    @SuppressWarnings("all")
+    static class Literal extends AnnotationLiteral<Meaty> implements Meaty {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final Meaty INSTANCE = new Literal();
+
+        private Literal() {
+        }
+
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/TestClassProducerTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/TestClassProducerTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.util.TypeLiteral;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Note that we add the class to the deployment so it is recognized as a bean and therefore the producer is also discovered.
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class TestClassProducerTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(List.class, TestClassProducerTest.class).build();
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testBean() {
+        Assertions.assertEquals("42", weld.select(new TypeLiteral<List<String>>() {
+        }).get().get(0));
+    }
+
+    @ApplicationScoped
+    @Produces
+    List<String> produceList() {
+        return when(mock(List.class).get(0)).thenReturn("42").getMock();
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/contexts/ContextsActivatedTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/contexts/ContextsActivatedTest.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.contexts;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class ContextsActivatedTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(Foo.class, Oof.class)
+            .activate(RequestScoped.class, SessionScoped.class).build();
+
+    @Test
+    public void testNormalScopes() {
+        Assertions.assertEquals(weld.select(Foo.class).get().getId(), weld.select(Foo.class).get().getId());
+        Assertions.assertEquals(weld.select(Oof.class).get().getId(), weld.select(Oof.class).get().getId());
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/contexts/Foo.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/contexts/Foo.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.contexts;
+
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class Foo {
+
+    private String id;
+
+    @PostConstruct
+    public void init() {
+        id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/contexts/InvalidScopeTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/contexts/InvalidScopeTest.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.contexts;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class InvalidScopeTest {
+
+    @Test
+    public void testFoo() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            // the container doesn't really even start here and it's not proper way to start it
+            // but it's suffiecient to check that only scopes can be activated
+            WeldInitiator.from(Foo.class).activate(SomeAnnotation.class);
+        });
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/contexts/Oof.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/contexts/Oof.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.contexts;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.SessionScoped;
+
+@SuppressWarnings("serial")
+@SessionScoped
+public class Oof implements Serializable {
+
+    private String id;
+
+    @PostConstruct
+    public void init() {
+        id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/contexts/SomeAnnotation.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/contexts/SomeAnnotation.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.contexts;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SomeAnnotation {
+    
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/event/DummyObserver.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/event/DummyObserver.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.event;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.jboss.weld.junit5.basic.Foo;
+
+@ApplicationScoped
+public class DummyObserver {
+
+    static final List<Foo> MESSAGES = new CopyOnWriteArrayList<>();
+
+    public void observeHelloMessage(@Observes Foo message) {
+        MESSAGES.add(message);
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/event/FireEventTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/event/FireEventTest.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.event;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.jboss.weld.junit5.basic.Foo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class FireEventTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(DummyObserver.class);
+
+    @Test
+    public void testEventFired() {
+        DummyObserver.MESSAGES.clear();
+        // Fire an event
+        weld.event().select(Foo.class).fire(new Foo());
+        Assertions.assertEquals(1, DummyObserver.MESSAGES.size());
+        Assertions.assertNull(DummyObserver.MESSAGES.get(0).getBar());
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/BarBean.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/BarBean.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.extensionInjection;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+@MyQualifier
+public class BarBean {
+
+    public String ping() {
+        return BarBean.class.getSimpleName();
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/FooBean.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/FooBean.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.extensionInjection;
+
+import javax.enterprise.context.Dependent;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Dependent
+public class FooBean {
+
+    public String ping() {
+        return FooBean.class.getSimpleName();
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/JUnit5ExtensionTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/JUnit5ExtensionTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.extensionInjection;
+
+import javax.inject.Inject;
+
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Basic test for JUnit 5 injection into parameter/field handled by Weld
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class JUnit5ExtensionTest {
+
+    @Inject
+    SomeBean bean;
+
+    @Test
+    public void testFieldInjection() {
+
+        // assert parameter injection works
+        Assertions.assertNotNull(bean);
+
+        bean.ping();
+    }
+
+    @Test
+    public void testparamInjection(FooBean foo) {
+        // assert field injection works
+        Assertions.assertNotNull(foo);
+        foo.ping();
+    }
+
+    @Test
+    public void testparamInjectionWithQualifier(@MyQualifier BarBean bar) {
+        // assert field injection works
+        Assertions.assertNotNull(bar);
+        bar.ping();
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/MyQualifier.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/MyQualifier.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.extensionInjection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Qualifier
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyQualifier {
+    
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/SomeBean.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/extensionInjection/SomeBean.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.extensionInjection;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class SomeBean {
+
+    public String ping() {
+        return SomeBean.class.getSimpleName();
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/Alpha.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/Alpha.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.ofpackage;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class Alpha {
+
+    private String value;
+
+    @PostConstruct
+    public void init() {
+        value = this.getClass().getSimpleName().toLowerCase();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/Bravo.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/Bravo.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.ofpackage;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class Bravo {
+
+    private String value;
+
+    @PostConstruct
+    public void init() {
+        value = this.getClass().getSimpleName().toLowerCase();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/OfPackageTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/OfPackageTest.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.ofpackage;
+
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class OfPackageTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.ofTestPackage();
+
+    @Test
+    public void testOfTestPackage() {
+        Assertions.assertEquals("alpha", weld.select(Alpha.class).get().getValue());
+        Assertions.assertTrue(weld.select(Bravo.class).isResolvable());
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PerClassLifecycleTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PerClassLifecycleTest.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.testLifecycle;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Note that we cannot be sure which method executes first - only one of them will do actual verification.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ExtendWith(WeldJunit5Extension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PerClassLifecycleTest {
+
+    @WeldSetup
+    public WeldInitiator initiator = WeldInitiator.of(new Weld(String.valueOf(System.currentTimeMillis()))
+        .disableDiscovery().addBeanClass(PlainBean.class));
+
+    String containerId = null;
+
+    @Test
+    public void first() {
+        if (containerId == null) {
+            containerId = WeldContainer.current().getId();
+        } else {
+            Assertions.assertEquals(containerId, WeldContainer.current().getId());
+        }
+    }
+
+    @Test
+    public void second() {
+        if (containerId == null) {
+            containerId = WeldContainer.current().getId();
+        } else {
+            Assertions.assertEquals(containerId, WeldContainer.current().getId());
+        }
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PlainBean.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PlainBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.testLifecycle;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class PlainBean {
+    
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
       <maven.compiler.target>1.7</maven.compiler.target>
       <!-- Versions -->
       <version.junit4>4.12</version.junit4>
-      <junit.platform.version>1.0.1</junit.platform.version>
-      <junit.jupiter.version>5.0.1</junit.jupiter.version>
-      <version.weld>2.4.4.Final</version.weld>
-      <version.weld3>3.0.0.Final</version.weld3>
+      <version.junit.platform>1.0.1</version.junit.platform>
+      <version.junit.jupiter>5.0.1</version.junit.jupiter>
+      <version.weld>2.4.5.Final</version.weld>
+      <version.weld3>3.0.1.Final</version.weld3>
       <version.mockito>2.7.19</version.mockito>
    </properties>
 
@@ -69,17 +69,17 @@
             <artifactId>junit</artifactId>
             <version>${version.junit4}</version>
          </dependency>
-         
+
          <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>${version.junit.jupiter}</version>
         </dependency>
 
          <dependency>
@@ -88,7 +88,7 @@
             <version>${version.mockito}</version>
             <scope>test</scope>
          </dependency>
-         
+
          <dependency>
              <groupId>org.jboss.weld</groupId>
              <artifactId>weld-junit-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
       <maven.compiler.target>1.7</maven.compiler.target>
       <!-- Versions -->
       <version.junit4>4.12</version.junit4>
+      <junit.platform.version>1.0.1</junit.platform.version>
+      <junit.jupiter.version>5.0.1</junit.jupiter.version>
       <version.weld>2.4.4.Final</version.weld>
       <version.weld3>3.0.0.Final</version.weld3>
       <version.mockito>2.7.19</version.mockito>
@@ -48,6 +50,8 @@
 
    <modules>
       <module>junit4</module>
+      <module>junit5</module>
+      <module>junit-common</module>
    </modules>
 
    <dependencyManagement>
@@ -65,12 +69,30 @@
             <artifactId>junit</artifactId>
             <version>${version.junit4}</version>
          </dependency>
+         
+         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
 
          <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${version.mockito}</version>
             <scope>test</scope>
+         </dependency>
+         
+         <dependency>
+             <groupId>org.jboss.weld</groupId>
+             <artifactId>weld-junit-common</artifactId>
+             <version>${project.version}</version>
          </dependency>
 
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
 
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.compiler.source>1.7</maven.compiler.source>
-      <maven.compiler.target>1.7</maven.compiler.target>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
       <!-- Versions -->
       <version.junit4>4.12</version.junit4>
       <version.junit.platform>1.0.1</version.junit.platform>


### PR DESCRIPTION
First shot at Junit 5 extension.
I was trying to make it as similar to JUnit 4 in usage as possible. However this requires some nasty hacks as JUnit 5 extensions are "stateless" and you cannot pass data from tests to extensions.

I also carried over tests from junit 4 extension and modified them to be Junit 5-style to make sure it works. There is still more testing to be done but we should first discuss whether we like this kind of approach or not really.

NOTE: some functionality(ContextImpl) is plain duplicate of what we have in Junit4 extension. We might want to create something like Weld-Junit-Common where this could be stored. For now I just copied it to make it clear what is needed/used in this extension.