### PR TITLE
Document JUnit 5 extension, re-work README structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 [![License](https://img.shields.io/badge/license-Apache%20License%202.0-yellow.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 The primary goal of this project is to provide simple and fast tools for CDI *unit/component* testing.
-The tools are implemented as JUnit extensions.
+The tools are implemented as JUnit 4 and JUnit 5 extensions.
 Supports Weld **2.4** (CDI 1.2) and **3.0** (CDI 2.0).
 
 ## The What
 
-Weld JUnit extension allows you to write unit tests for your beans regardless of the target environment (Java SE, Java EE, etc.).
+Weld JUnit extensions allow you to write unit tests for your beans regardless of the target environment (Java SE, Java EE, etc.).
 It starts a real CDI container in minimal configuration meaning you can leverage all bean capabilities - injection, interception, events, etc. - without the need for mocking.
-This extension boots up CDI container before each test method and shuts it down afterwards.
-You have the power to customize what beans, extension, interceptors (and so on) are going to be in the container.
+These extensions boot up CDI container before each test container run and shut it down afterwards.
+You have the power to customize what beans, extensions, interceptors (and so on) are going to be in the container.
 Furthermore, you can `@Inject` directly in your test class - and the list goes on...
 
 
@@ -22,217 +22,18 @@ Furthermore, you can `@Inject` directly in your test class - and the list goes o
 As a matter of fact, one could have a unit test for CDI bean without running a container, but that would present quite a few drawbacks.
 Simulating field injection to start with, then interceptors and/or decorators - all in all, quite a challenge.
 There are frameworks to make this easier such as [Mockito](http://site.mockito.org/); but use too many mocks and things get tangled real quick.
-So we came with JUnit extension which allows you to use actual CDI container instead of complex simulations.
+So we came with JUnit extensions which allow you to use actual CDI container instead of complex simulations.
 There is no need to change the way you develop your CDI components if you have a real container to test it with.
 Besides, it's easy to combine this approach with mocking frameworks (see also [Adding mock beans](#adding-mock-beans)).
 
-## Table of contents
+## How To Use Each Extension
 
-* [JUnit 4](#junit-4)
-  * [WeldInitiator](#weldinitiator)
-    * [Flat Deployment](#flat-deployment)
-    * [Convenient Starting Points](#convenient-starting-points)
-      * [Test class injection](#test-class-injection)
-      * [Activating context for a normal scope](#activating-context-for-a-normal-scope)
-      * [Adding mock beans](#adding-mock-beans)
+This project consists of three modules.
+Below is a list with links to detailed README of each extension:
 
-## JUnit 4
-
-```xml
-<dependency>
-  <groupId>org.jboss.weld</groupId>
-  <artifactId>weld-junit4</artifactId>
-  <version>${version.weld-junit}</version>
-</dependency>
-```
-
-### WeldInitiator
-
-`org.jboss.weld.junit.WeldInitiator` is a `TestRule` (JUnit 4.9+) which allows to *start/stop* a Weld container per test method execution.
-The container is configured through a provided `org.jboss.weld.environment.se.Weld` instance.
-By default, the container is optimized for testing purposes, i.e. with automatic discovery and concurrent deployment disabled (see also `WeldInitiator.createWeld()`).
-However, it is possible to provide a customized `Weld` instance  - see also `WeldInitiator.of(Weld)` and `WeldInitiator.from(Weld)` methods.
-`WeldInitiator` also implements `javax.enterprise.inject.Instance` and therefore might be used to perform programmatic lookup of bean instances.
-
-#### Flat Deployment
-
-Unlike when using [Arquillian Weld embedded container](https://github.com/arquillian/arquillian-container-weld), bean archive isolation is enabled by default.
-This behaviour can be changed by setting a system property `org.jboss.weld.se.archive.isolation` to `false` or through the `Weld.property()` method.
-In that case, Weld will use a _"flat"_ deployment structure - all bean classes share the same bean archive and all beans.xml descriptors are automatically merged into one.
-Thus alternatives, interceptors and decorators selected/enabled for a bean archive will be enabled for the whole application.
-
-#### Convenient Starting Points
-
-A convenient static method `WeldInitiator.of(Class<?>...)` is also provided - in this case, the container is optimized for testing purposes and only the given bean classes are considered.
-
-```java
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Rule;
-import org.junit.Test;
-
-class SimpleTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.of(Foo.class);
-
-    @Test
-    public void testFoo() {
-        // Note that Weld container is started automatically
-
-        // WeldInitiator can be used to perform programmatic lookup of beans
-        assertEquals("baz", weld.select(Foo.class).get().getBaz());
-
-        // WeldInitiator can be used to fire a CDI event
-        weld.event().select(Baz.class).fire(new Baz());
-    }
-
-}
-```
-
-It's also possible to use `WeldInitiator.ofTestPackage()` - the container is optimized for testing purposes and all the classes from the test class package are added automatically.
-
-```java
-
-class AnotherSimpleTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.ofTestPackage();
-
-    @Test
-    public void testFoo() {
-        // Alpha comes from the same package as AnotherSimpleTest
-        assertEquals(1, weld.select(Alpha.class).ping());
-    }
-
-}
-```
-
-Furthermore, `WeldInitiator.Builder` can be used to customize the final `WeldInitiator` instance, e.g. to *activate a context for a given normal scope* or to *inject the test class*.
-
-##### Test class injection
-
-Sometimes, the programmatic lookup can imply unnecessary overhead, e.g. an annotation literal must be used for parameterized types and qualifiers with members.
-`WeldInitiator.Builder.inject(Object)` instructs the rule to inject the given non-contextual instance once the container is started, i.e. during each test method execution:
-
-```java
-class InjectTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.from(Foo.class).inject(this).build();
-
-  // Gets injected by WeldInitiator when testFoo() is about to be run
-    @Inject
-    @MyQualifier
-    Foo foo;
-
-    @Test
-    public void testFoo() {
-        assertEquals(42, foo.getValue());
-    }
-}
-```
-
-##### Activating context for a normal scope
-
-`WeldInitiator.Builder.activate(Object)` makes it possible to activate and deactivate contexts for the specified normal scopes for each test method execution:
-
-```java
-class ContextsActivatedTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.from(Foo.class, Oof.class)
-            .activate(RequestScoped.class, SessionScoped.class).build();
-
-    @Test
-    public void testFoo() {
-        // Contexts for @RequestScoped and @SessionScoped are active!
-        // Foo is @RequestScoped
-        weld.select(Foo.class).get().doSomethingImportant();
-        // Oof is @SessionScoped
-        weld.select(Oof.class).get().doSomethingVeryImportant();
-    }
-}
-```
-
-##### Adding mock beans
-
-Sometimes you might need to add a mock for a bean that cannot be part of the test deployment, e.g. the original bean implementation has dependencies which cannot be satisfied in the test environment.
-Very often, it's an ideal use case for mocking libraries, ie. to create a bean instance with the desired behavior.
-In this case, there are two options.
-The first option is to add a [producer method](http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#producer_method) to the test class and add the test class to the deployment.
-The test class will be recognized as a bean and therefore the producer will also be discovered.
-
-```java
-interface Bar {
-  String ping();
-}
-
-class Foo {
-  @Inject
-  Bar bar;
-
-  String ping() {
-    return bar.ping();
-  }
-}
-
-class TestClassProducerTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.from(Foo.class, MockBeanTest.class).build();
-
-    @ApplicationScoped
-    @Produces
-    Bar produceBar() {
-      // Mock object provided by Mockito
-      return Mockito.when(Mockito.mock(Bar.class).ping()).thenReturn("pong").getMock());
-    }
-
-    @Test
-    public void testFoo() {
-        Assert.assertEquals("pong", weld.select(Foo.class).get().ping());
-    }
-}
-```
-
-This should work in most of the cases (assuming the test class [meets some conditions](http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#what_classes_are_beans)) although it's a little bit cumbersome.
-The second option is `WeldInitiator.Builder.addBeans(Bean<?>...)` which makes it possible to add beans during `AfterBeanDiscovery` phase easily.
-You can provide your own `javax.enterprise.inject.spi.Bean` implementation or make use of existing solutions such as DeltaSpike [BeanBuilder](https://github.com/apache/deltaspike/blob/master/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/bean/BeanBuilder.java) or for most use cases a convenient `org.jboss.weld.junit4.MockBean` should be sufficient.
-Use `org.jboss.weld.junit4.MockBean.builder()` to obtain a new builder instance.
-
-```java
-interface Bar {
-  String ping();
-}
-
-class Foo {
-  @Inject
-  Bar bar;
-
-  String ping() {
-    return bar.ping();
-  }
-}
-
-class AddBeanTest {
-
-    @Rule
-    public WeldInitiator weld = WeldInitiator.from(Foo.class).addBeans(createBarBean()).build();
-
-    static Bean<?> createBarBean() {
-        return MockBean.builder()
-                .types(Bar.class)
-                .scope(ApplicationScoped.class)
-                .creating(
-                       // Mock object provided by Mockito
-                       Mockito.when(Mockito.mock(Bar.class).ping()).thenReturn("pong").getMock())
-                .build();
-    }
-
-    @Test
-    public void testFoo() {
-        assertEquals("pong", weld.select(Foo.class).get().ping());
-    }
-}
-```
+* JUnit 4 extension
+  * [JUnit 4 extension using `@Rule` mechanism](junit4/README.md)
+* JUnit 5
+  * [JUnit 5 extension using the `@ExtendWith` mechanism](junit5/README.md)
+* JUnit-common
+  * Houses the parts of code shared by both extensions

--- a/junit4/README.md
+++ b/junit4/README.md
@@ -1,0 +1,215 @@
+# Weld JUnit 4 Extension
+
+Weld JUnit 4 extension uses the original JUnit extension system via `@Rule` annotation.
+It requires JUnit 4.9+ and Java 8.
+
+## Table of contents
+
+* [Maven Artifact](#maven-artifact)
+* [WeldInitiator](#weldinitiator)
+  * [Flat Deployment](#flat-deployment)
+  * [Convenient Starting Points](#convenient-starting-points)
+    * [Test class injection](#test-class-injection)
+    * [Activating context for a normal scope](#activating-context-for-a-normal-scope)
+    * [Adding mock beans](#adding-mock-beans)
+
+## Maven Artifact
+
+```xml
+<dependency>
+  <groupId>org.jboss.weld</groupId>
+  <artifactId>weld-junit4</artifactId>
+  <version>${version.weld-junit}</version>
+</dependency>
+```
+
+## WeldInitiator
+
+`org.jboss.weld.junit4.WeldInitiator` is a `TestRule` (JUnit 4.9+) which allows to *start/stop* a Weld container per test method execution.
+The container is configured through a provided `org.jboss.weld.environment.se.Weld` instance.
+By default, the container is optimized for testing purposes, i.e. with automatic discovery and concurrent deployment disabled (see also `WeldInitiator.createWeld()`).
+However, it is possible to provide a customized `Weld` instance  - see also `WeldInitiator.of(Weld)` and `WeldInitiator.from(Weld)` methods.
+`WeldInitiator` also implements `javax.enterprise.inject.Instance` and therefore might be used to perform programmatic lookup of bean instances.
+
+### Flat Deployment
+
+Unlike when using [Arquillian Weld embedded container](https://github.com/arquillian/arquillian-container-weld), bean archive isolation is enabled by default.
+This behaviour can be changed by setting a system property `org.jboss.weld.se.archive.isolation` to `false` or through the `Weld.property()` method.
+In that case, Weld will use a _"flat"_ deployment structure - all bean classes share the same bean archive and all beans.xml descriptors are automatically merged into one.
+Thus alternatives, interceptors and decorators selected/enabled for a bean archive will be enabled for the whole application.
+
+### Convenient Starting Points
+
+A convenient static method `WeldInitiator.of(Class<?>...)` is also provided - in this case, the container is optimized for testing purposes and only the given bean classes are considered.
+
+```java
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+class SimpleTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+    @Test
+    public void testFoo() {
+        // Note that Weld container is started automatically
+
+        // WeldInitiator can be used to perform programmatic lookup of beans
+        assertEquals("baz", weld.select(Foo.class).get().getBaz());
+
+        // WeldInitiator can be used to fire a CDI event
+        weld.event().select(Baz.class).fire(new Baz());
+    }
+
+}
+```
+
+It's also possible to use `WeldInitiator.ofTestPackage()` - the container is optimized for testing purposes and all the classes from the test class package are added automatically.
+
+```java
+
+class AnotherSimpleTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.ofTestPackage();
+
+    @Test
+    public void testFoo() {
+        // Alpha comes from the same package as AnotherSimpleTest
+        assertEquals(1, weld.select(Alpha.class).ping());
+    }
+
+}
+```
+
+Furthermore, `WeldInitiator.Builder` can be used to customize the final `WeldInitiator` instance, e.g. to *activate a context for a given normal scope* or to *inject the test class*.
+
+#### Test class injection
+
+Sometimes, the programmatic lookup can imply unnecessary overhead, e.g. an annotation literal must be used for parameterized types and qualifiers with members.
+`WeldInitiator.Builder.inject(Object)` instructs the rule to inject the given non-contextual instance once the container is started, i.e. during each test method execution:
+
+```java
+class InjectTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.from(Foo.class).inject(this).build();
+
+  // Gets injected by WeldInitiator when testFoo() is about to be run
+    @Inject
+    @MyQualifier
+    Foo foo;
+
+    @Test
+    public void testFoo() {
+        assertEquals(42, foo.getValue());
+    }
+}
+```
+
+#### Activating context for a normal scope
+
+`WeldInitiator.Builder.activate(Object)` makes it possible to activate and deactivate contexts for the specified normal scopes for each test method execution:
+
+```java
+class ContextsActivatedTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.from(Foo.class, Oof.class)
+            .activate(RequestScoped.class, SessionScoped.class).build();
+
+    @Test
+    public void testFoo() {
+        // Contexts for @RequestScoped and @SessionScoped are active!
+        // Foo is @RequestScoped
+        weld.select(Foo.class).get().doSomethingImportant();
+        // Oof is @SessionScoped
+        weld.select(Oof.class).get().doSomethingVeryImportant();
+    }
+}
+```
+
+#### Adding mock beans
+
+Sometimes you might need to add a mock for a bean that cannot be part of the test deployment, e.g. the original bean implementation has dependencies which cannot be satisfied in the test environment.
+Very often, it's an ideal use case for mocking libraries, ie. to create a bean instance with the desired behavior.
+In this case, there are two options.
+The first option is to add a [producer method](http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#producer_method) to the test class and add the test class to the deployment.
+The test class will be recognized as a bean and therefore the producer will also be discovered.
+
+```java
+interface Bar {
+  String ping();
+}
+
+class Foo {
+  @Inject
+  Bar bar;
+
+  String ping() {
+    return bar.ping();
+  }
+}
+
+class TestClassProducerTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.from(Foo.class, MockBeanTest.class).build();
+
+    @ApplicationScoped
+    @Produces
+    Bar produceBar() {
+      // Mock object provided by Mockito
+      return Mockito.when(Mockito.mock(Bar.class).ping()).thenReturn("pong").getMock());
+    }
+
+    @Test
+    public void testFoo() {
+        Assert.assertEquals("pong", weld.select(Foo.class).get().ping());
+    }
+}
+```
+
+This should work in most of the cases (assuming the test class [meets some conditions](http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#what_classes_are_beans)) although it's a little bit cumbersome.
+The second option is `WeldInitiator.Builder.addBeans(Bean<?>...)` which makes it possible to add beans during `AfterBeanDiscovery` phase easily.
+You can provide your own `javax.enterprise.inject.spi.Bean` implementation or make use of existing solutions such as DeltaSpike [BeanBuilder](https://github.com/apache/deltaspike/blob/master/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/bean/BeanBuilder.java) or for most use cases a convenient `org.jboss.weld.junit4.MockBean` should be sufficient.
+Use `org.jboss.weld.junit.MockBean.builder()` to obtain a new builder instance.
+
+```java
+interface Bar {
+  String ping();
+}
+
+class Foo {
+  @Inject
+  Bar bar;
+
+  String ping() {
+    return bar.ping();
+  }
+}
+
+class AddBeanTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.from(Foo.class).addBeans(createBarBean()).build();
+
+    static Bean<?> createBarBean() {
+        return MockBean.builder()
+                .types(Bar.class)
+                .scope(ApplicationScoped.class)
+                .creating(
+                       // Mock object provided by Mockito
+                       Mockito.when(Mockito.mock(Bar.class).ping()).thenReturn("pong").getMock())
+                .build();
+    }
+
+    @Test
+    public void testFoo() {
+        assertEquals("pong", weld.select(Foo.class).get().ping());
+    }
+}
+```

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -1,0 +1,279 @@
+# Weld JUnit 5 Extension
+
+This extension uses the extension mechanism introduced in JUnit 5.
+Therefore, in order to use this extension in your test, you have to annotate your test class with `@ExtendWith(WeldJunit5Extension.class)`.
+It will automatically inject into all your `@Inject` fields in given test instance and start/stop Weld SE container based on your configuration.
+Even if no configuration is provided, the default one will kick in.
+Supports both test lifecycles - per method and per class.
+
+Requires JUnit 5 and Java 8.
+
+## Table of contents
+
+* [Maven Artifact](#maven-artifact)
+* [Basic Example](#basic-example)
+* [WeldInitiator](#weldinitiator)
+  * [Flat Deployment](#flat-deployment)
+  * [Convenient Starting Points](#convenient-starting-points)
+    * [Test class injection](#test-class-injection)
+    * [Activating context for a normal scope](#activating-context-for-a-normal-scope)
+    * [Adding mock beans](#adding-mock-beans)
+
+## Maven Artifact
+
+```xml
+<dependency>
+  <groupId>org.jboss.weld</groupId>
+  <artifactId>weld-junit5</artifactId>
+  <version>${version.weld-junit}</version>
+</dependency>
+```
+
+## Basic Example
+
+The simplest way to use this extension is to annotate your test class with `@ExtendWith(WeldJunit5Extension.class)`.
+In such case, Weld container will still be started before each test is run and stopped afterwards.
+This default behaviour includes:
+
+* Bootstrapping Weld SE container with
+  * Disabled discovery
+  * Added test class package as source of beans
+  * Disabled concurrent deployment
+* Injecting into test instance, e.g. into all `@Inject` fields
+* Injecting into method parameters of your test methods
+  * In case the type of the parameter matches a known and resolvable bean
+* Shutting down the container after test is done
+
+And this is how you achieve it:
+
+```java
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(WeldJunit5Extension.class)
+class BasicUsageTest {
+
+    @Inject
+    MyBean myBean;
+
+    @Test
+    public void testFoo(MyOtherBean otherBean) {
+      // Weld SE container is bootstrapped here and the injection points are resolved
+    }
+}
+```
+
+## WeldInitiator
+
+`org.jboss.weld.junit5.WeldInitiator` is an entry point you will want to define if you wish to customize how we bootstrap Weld.
+The container is configured through a provided `org.jboss.weld.environment.se.Weld` instance.
+By default, the container is optimized for testing purposes, i.e. with automatic discovery and concurrent deployment disabled (see also `WeldInitiator.createWeld()`).
+However, it is possible to provide a customized `Weld` instance  - see also `WeldInitiator.of(Weld)` and `WeldInitiator.from(Weld)` methods.
+`WeldInitiator` also implements `javax.enterprise.inject.Instance` and therefore might be used to perform programmatic lookup of bean instances.
+
+`WeldInitiator` should be a public field annotated with `@org.jboss.weld.junit5.WeldSetup`.
+From there you can use static methods:
+
+```java
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(WeldJunit5Extension.class)
+class MyNewTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(Some.class);
+
+    @Test
+    public void testFoo() {...}
+}
+```
+
+### Flat Deployment
+
+Unlike when using [Arquillian Weld embedded container](https://github.com/arquillian/arquillian-container-weld), bean archive isolation is enabled by default.
+This behaviour can be changed by setting a system property `org.jboss.weld.se.archive.isolation` to `false` or through the `Weld.property()` method.
+In that case, Weld will use a _"flat"_ deployment structure - all bean classes share the same bean archive and all beans.xml descriptors are automatically merged into one.
+Thus alternatives, interceptors and decorators selected/enabled for a bean archive will be enabled for the whole application.
+
+### Convenient Starting Points
+
+A convenient static method `WeldInitiator.of(Class<?>...)` is also provided - in this case, the container is optimized for testing purposes and only the given bean classes are considered.
+
+```java
+
+@ExtendWith(WeldJunit5Extension.class)
+class SimpleTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+    @Test
+    public void testFoo() {
+        // Note that Weld container is started automatically
+
+        // WeldInitiator can be used to perform programmatic lookup of beans
+        assertEquals("baz", weld.select(Foo.class).get().getBaz());
+
+        // WeldInitiator can be used to fire a CDI event
+        weld.event().select(Baz.class).fire(new Baz());
+    }
+
+}
+```
+
+It's also possible to use `WeldInitiator.ofTestPackage()` - the container is optimized for testing purposes and all the classes from the test class package are added automatically.
+
+```java
+
+@ExtendWith(WeldJunit5Extension.class)
+class AnotherSimpleTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.ofTestPackage();
+
+    @Test
+    public void testFoo() {
+        // Alpha comes from the same package as AnotherSimpleTest
+        assertEquals(1, weld.select(Alpha.class).ping());
+    }
+
+}
+```
+
+Furthermore, `WeldInitiator.Builder` can be used to customize the final `WeldInitiator` instance, e.g. to *activate a context for a given normal scope* or to *inject the test class*.
+
+#### Test class injection
+
+Everytime `WeldJunit5Extension` processes your test instance, it will automatically resolve all `@Inject` fields as well as attempt to resolve any test method parameters, should they be injectable beans.
+
+```java
+@ExtendWith(WeldJunit5Extension.class)
+class InjectTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(Foo.class).build();
+
+  // Gets injected before executing test
+    @Inject
+    @MyQualifier
+    Foo foo;
+
+    @Test
+    public void testFoo(Foo fooAsParam) {
+        assertEquals(42, foo.getValue());
+        assertEquals(42, fooAsParam.getValue());
+    }
+}
+```
+
+#### Activating context for a normal scope
+
+`WeldInitiator.Builder.activate(Class<? extends Annotation>...)` makes it possible to activate and deactivate contexts for the specified normal scopes for each test method execution:
+
+```java
+@ExtendWith(WeldJunit5Extension.class)
+class ContextsActivatedTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(Foo.class, Oof.class)
+            .activate(RequestScoped.class, SessionScoped.class).build();
+
+    @Test
+    public void testFoo() {
+        // Contexts for @RequestScoped and @SessionScoped are active!
+        // Foo is @RequestScoped
+        weld.select(Foo.class).get().doSomethingImportant();
+        // Oof is @SessionScoped
+        weld.select(Oof.class).get().doSomethingVeryImportant();
+    }
+}
+```
+
+#### Adding mock beans
+
+Sometimes you might need to add a mock for a bean that cannot be part of the test deployment, e.g. the original bean implementation has dependencies which cannot be satisfied in the test environment.
+Very often, it's an ideal use case for mocking libraries, ie. to create a bean instance with the desired behavior.
+In this case, there are two options.
+The first option is to add a [producer method](http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#producer_method) to the test class and add the test class to the deployment.
+The test class will be recognized as a bean and therefore the producer will also be discovered.
+
+```java
+interface Bar {
+  String ping();
+}
+
+class Foo {
+  @Inject
+  Bar bar;
+
+  String ping() {
+    return bar.ping();
+  }
+}
+
+@ExtendWith(WeldJunit5Extension.class)
+class TestClassProducerTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(Foo.class, MockBeanTest.class).build();
+
+    @ApplicationScoped
+    @Produces
+    Bar produceBar() {
+      // Mock object provided by Mockito
+      return Mockito.when(Mockito.mock(Bar.class).ping()).thenReturn("pong").getMock());
+    }
+
+    @Test
+    public void testFoo() {
+        Assert.assertEquals("pong", weld.select(Foo.class).get().ping());
+    }
+}
+```
+
+This should work in most of the cases (assuming the test class [meets some conditions](http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#what_classes_are_beans)) although it's a little bit cumbersome.
+The second option is `WeldInitiator.Builder.addBeans(Bean<?>...)` which makes it possible to add beans during `AfterBeanDiscovery` phase easily.
+You can provide your own `javax.enterprise.inject.spi.Bean` implementation or make use of existing solutions such as DeltaSpike [BeanBuilder](https://github.com/apache/deltaspike/blob/master/deltaspike/core/api/src/main/java/org/apache/deltaspike/core/util/bean/BeanBuilder.java) or for most use cases a convenient `org.jboss.weld.junit4.MockBean` should be sufficient.
+Use `org.jboss.weld.junit.MockBean.builder()` to obtain a new builder instance.
+
+```java
+interface Bar {
+  String ping();
+}
+
+class Foo {
+  @Inject
+  Bar bar;
+
+  String ping() {
+    return bar.ping();
+  }
+}
+
+@ExtendWith(WeldJunit5Extension.class)
+class AddBeanTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(Foo.class).addBeans(createBarBean()).build();
+
+    static Bean<?> createBarBean() {
+        return MockBean.builder()
+                .types(Bar.class)
+                .scope(ApplicationScoped.class)
+                .creating(
+                       // Mock object provided by Mockito
+                       Mockito.when(Mockito.mock(Bar.class).ping()).thenReturn("pong").getMock())
+                .build();
+    }
+
+    @Test
+    public void testFoo() {
+        assertEquals("pong", weld.select(Foo.class).get().ping());
+    }
+}
+```


### PR DESCRIPTION
Addresses issue #10 

For JUnit 4 README - mostly cut & paste of previous text
For JUnit 5 README - copy of JUnit 4 with corrected imports and test syntax; also omitted `WeldInitiator.Builder.inject()` part