### PR TITLE
Adds the @EnableWeld meta-annotation.

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/EnableWeld.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/EnableWeld.java
@@ -1,0 +1,41 @@
+package org.jboss.weld.junit5;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Meta-annotation that allows test classes to be extended with <code>&#64;EnableWeld</code>
+ * instead of <code>&#64;ExtendWith(WeldJunit5Extension.class)</code>.
+ * 
+ * <pre><br>
+ * &#64;EnableWeld
+ * public class SimpleTest {
+ *
+ *     // Injected automatically
+ *     &#64;Inject
+ *     Foo foo;
+ *
+ *     &#64;Test
+ *     public void testFoo() {
+ *         // Weld container is started automatically
+ *         assertEquals("baz", foo.getBaz());
+ *     }
+ * }
+ * </pre>
+ *
+ * @author <a href="mailto:smoyer1@selesy.com">Steve Moyer</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Documented
+@Inherited
+@ExtendWith(WeldJunit5Extension.class)
+public @interface EnableWeld {
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/EnableWeldTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/EnableWeldTest.java
@@ -1,0 +1,24 @@
+package org.jboss.weld.junit5.basic;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.jboss.weld.junit5.EnableWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@EnableWeld
+public class EnableWeldTest {
+
+	@Inject
+	BeanManager beanManager;
+	
+	@Test
+	@DisplayName("@EnableWeld initializes the Weld CDI container")
+	void enableWeldAnnotationInitializesTheWeldContainer() {
+		assertNotNull(beanManager);
+	}
+	
+}


### PR DESCRIPTION
Simplifies using weld-junit5 with a JUnit 5 test class - replaces ```@ExtendWith(WeldJunit5Extension.class)``` with ```@Weld```.