### PR TITLE
Adds attributes for Weld setup to @EnableWeld.

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/EnableWeld.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/EnableWeld.java
@@ -10,10 +10,10 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Meta-annotation that allows test classes to be extended with <code>&#64;EnableWeld</code>
- * instead of <code>&#64;ExtendWith(WeldJunit5Extension.class)</code>.
+ * Meta-annotation that allows test classes to be extended with <code>&#64;EnableWeld</code> instead of <code>&#64;ExtendWith(WeldJunit5Extension.class)</code>.
  * 
- * <pre><br>
+ * <pre>
+ * <br>
  * &#64;EnableWeld
  * public class SimpleTest {
  *
@@ -37,5 +37,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Inherited
 @ExtendWith(WeldJunit5Extension.class)
 public @interface EnableWeld {
+
+    Class<?>[] testBeans() default {};
+
+    boolean testPackage() default false;
 
 }

--- a/junit5/src/test/java/org/jboss/weld/junit5/WeldAssertions.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/WeldAssertions.java
@@ -1,0 +1,42 @@
+package org.jboss.weld.junit5;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.inject.Instance;
+
+public class WeldAssertions {
+
+    private WeldAssertions() {
+    }
+
+    public static void assertUnresolvable(Instance<?> instance) {
+        assertUnresolvable(instance, () -> null);
+    }
+
+    public static void assertUnresolvable(Instance<?> instance, Supplier<String> messageSupplier) {
+        if (isResolvable(instance)) {
+            fail(messageSupplier);
+        }
+    }
+
+    public static void assertResolvable(Instance<?> instance) {
+        assertResolvable(instance, () -> null);
+    }
+
+    public static void assertResolvable(Instance<?> instance, Supplier<String> messageSupplier) {
+        if (isUnresolvable(instance)) {
+            fail(messageSupplier);
+        }
+    }
+
+    static boolean isResolvable(Instance<?> instance) {
+        return !isUnresolvable(instance);
+    }
+
+    static boolean isUnresolvable(Instance<?> instance) {
+        return instance.isUnsatisfied() || instance.isAmbiguous();
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/EnableWeldOnClassWithBeansTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/EnableWeldOnClassWithBeansTest.java
@@ -1,0 +1,21 @@
+package org.jboss.weld.junit5.basic;
+
+import static org.jboss.weld.junit5.WeldAssertions.assertResolvable;
+import static org.jboss.weld.junit5.WeldAssertions.assertUnresolvable;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.ofpackage.Alpha;
+import org.junit.jupiter.api.Test;
+
+@EnableWeld(testBeans = Foo.class)
+public class EnableWeldOnClassWithBeansTest {
+
+    @Test
+    void testOfTestBeans() {
+        assertResolvable(CDI.current().select(Foo.class));
+        assertUnresolvable(CDI.current().select(Alpha.class));
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/EnableWeldOnMethodWithBeansTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/EnableWeldOnMethodWithBeansTest.java
@@ -1,0 +1,34 @@
+package org.jboss.weld.junit5.basic;
+
+import static org.jboss.weld.junit5.WeldAssertions.assertResolvable;
+import static org.jboss.weld.junit5.WeldAssertions.assertUnresolvable;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.ofpackage.Alpha;
+import org.junit.jupiter.api.Test;
+
+public class EnableWeldOnMethodWithBeansTest {
+
+    @Inject
+    BeanManager beanManager;
+
+    @Test
+    @EnableWeld(testBeans = Foo.class)
+    void testOfTestBeans() {
+        assertResolvable(CDI.current().select(Foo.class));
+        assertUnresolvable(CDI.current().select(Alpha.class));
+        assertNotNull(beanManager);
+    }
+
+    @Test
+    void weldIsNotInitialized() {
+        assertNull(beanManager);
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/EnableWeldOnClassOfPackageTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/EnableWeldOnClassOfPackageTest.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.ofpackage;
+
+import static org.jboss.weld.junit5.WeldAssertions.assertResolvable;
+import static org.jboss.weld.junit5.WeldAssertions.assertUnresolvable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.basic.Foo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Steve Moyer
+ */
+@EnableWeld(testPackage = true)
+public class EnableWeldOnClassOfPackageTest {
+
+    @Test
+    void testOfTestPackage() {
+        assertEquals("alpha", CDI.current().select(Alpha.class, new Annotation[0]).get().getValue());
+        assertResolvable(CDI.current().select(Bravo.class));
+        assertUnresolvable(CDI.current().select(Foo.class));
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/EnableWeldOnMethodOfPackageTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/ofpackage/EnableWeldOnMethodOfPackageTest.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.ofpackage;
+
+import static org.jboss.weld.junit5.WeldAssertions.assertResolvable;
+import static org.jboss.weld.junit5.WeldAssertions.assertUnresolvable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.basic.Foo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Steve Moyer
+ */
+public class EnableWeldOnMethodOfPackageTest {
+
+    @Inject
+    BeanManager beanManager;
+
+    @Test
+    @EnableWeld(testPackage = true)
+    void testOfTestPackageWithTrue() {
+        assertEquals("alpha", CDI.current().select(Alpha.class, new Annotation[0]).get().getValue());
+        assertResolvable(CDI.current().select(Bravo.class));
+        assertUnresolvable(CDI.current().select(Foo.class));
+        assertNotNull(beanManager);
+    }
+
+    @Test
+    void weldIsNotInitialized() {
+        assertNull(beanManager);
+    }
+
+}


### PR DESCRIPTION
This feature allows ```WeldInitiator.of()``` and ```WeldInitiator.ofTestPackage()```
to be specified as attributes of the ```@EnableWeld``` annotation and thus
allows different configurations for each test method in a class.  As
with most JUnit 5 extensions, the method-level annotations take
precedence over the class-level annotations.

Resolves #14