### PR TITLE
MockBean - make it possible to specify the bean class

### DIFF
--- a/junit-common/src/main/java/org/jboss/weld/junit/AbstractWeldInitiator.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/AbstractWeldInitiator.java
@@ -89,7 +89,8 @@ public abstract class AbstractWeldInitiator implements Instance<Object>, Contain
     protected volatile WeldContainer container;
 
     protected AbstractWeldInitiator(Weld weld, List<Object> instancesToInject, Set<Class<? extends Annotation>> scopesToActivate, Set<Bean<?>> beans,
-            Map<String, Object> resources, Function<InjectionPoint, Object> ejbFactory, Function<InjectionPoint, Object> persistenceUnitFactory, Function<InjectionPoint, Object> persistenceContextFactory) {
+            Map<String, Object> resources, Function<InjectionPoint, Object> ejbFactory, Function<InjectionPoint, Object> persistenceUnitFactory,
+            Function<InjectionPoint, Object> persistenceContextFactory) {
         this.instancesToInject = new ArrayList<>();
         for (Object instance : instancesToInject) {
             this.instancesToInject.add(createToInject(instance));
@@ -99,6 +100,14 @@ public abstract class AbstractWeldInitiator implements Instance<Object>, Contain
         this.weld = weld;
         if (hasScopesToActivate() || hasBeansToAdd()) {
             this.extension = new WeldCDIExtension(this.scopesToActivate, this.beans);
+            for (Bean<?> bean : this.beans) {
+                if (bean instanceof MockBean) {
+                    MockBean<?> mockBean = (MockBean<?>) bean;
+                    if (mockBean.isAlternative() && mockBean.isSelectForSyntheticBeanArchive()) {
+                        this.weld.addAlternative(mockBean.getBeanClass());
+                    }
+                }
+            }
             this.weld.addExtension(this.extension);
         } else {
             this.extension = null;

--- a/junit4/src/test/java/org/jboss/weld/junit4/bean/AlternativeMockBeanTest.java
+++ b/junit4/src/test/java/org/jboss/weld/junit4/bean/AlternativeMockBeanTest.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit4.bean;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.enterprise.context.Dependent;
+
+import org.jboss.weld.junit.MockBean;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class AlternativeMockBeanTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.from(SimpleService.class)
+            .addBeans(MockBean.builder().types(MyService.class).selectedAlternative(CoolService.class).create(c -> new CoolService()).build()).build();
+
+    @Test
+    public void testAlternativeBeanSelected() {
+        assertEquals(1000, weld.select(MyService.class).get().doBusiness());
+    }
+
+    interface MyService {
+
+        int doBusiness();
+
+    }
+
+    @Dependent
+    static class SimpleService implements MyService {
+
+        @Override
+        public int doBusiness() {
+            return 0;
+        }
+    }
+
+    static class CoolService implements MyService {
+
+        @Override
+        public int doBusiness() {
+            return 1000;
+        }
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/AlternativeMockBeanTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/AlternativeMockBeanTest.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean;
+
+import javax.enterprise.context.Dependent;
+
+import org.jboss.weld.junit.MockBean;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@EnableWeld
+public class AlternativeMockBeanTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(SimpleService.class)
+            .addBeans(MockBean.builder().types(MyService.class).selectedAlternative().beanClass(CoolService.class).create(c -> new CoolService()).build())
+            .build();
+
+    @Test
+    public void testAlternativeBeanSelected() {
+        Assertions.assertEquals(1000, weld.select(MyService.class).get().doBusiness());
+    }
+
+    interface MyService {
+
+        int doBusiness();
+
+    }
+
+    @Dependent
+    static class SimpleService implements MyService {
+
+        @Override
+        public int doBusiness() {
+            return 0;
+        }
+    }
+
+    static class CoolService implements MyService {
+
+        @Override
+        public int doBusiness() {
+            return 1000;
+        }
+    }
+
+}


### PR DESCRIPTION
- also add convenient MockBean.Builder.selectedAlternative()
- resolves #22