### PR TITLE
WeldInitiator's from() and of() methods should support extensions as …

### DIFF
--- a/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/AddExtensionAsBeanClassWithFromMethodTest.java
+++ b/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/AddExtensionAsBeanClassWithFromMethodTest.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit4.bean.extension;
+
+import org.jboss.weld.inject.WeldInstance;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class AddExtensionAsBeanClassWithFromMethodTest {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.from(GoodOldBean.class, MyExtension.class).build();
+
+    @Test
+    public void testThatClassIsRecognizedAsExtension() {
+        // GoodOldBean should be resolvable
+        Assert.assertTrue(weld.select(GoodOldBean.class).isResolvable());
+        WeldInstance<MyExtension> extInstance = weld.select(MyExtension.class);
+        // extension should be resolvable and should have observed the other bean
+        Assert.assertTrue(extInstance.isResolvable());
+        Assert.assertTrue(extInstance.get().beanObserved());
+    }
+}

--- a/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/AddExtensionAsBeanClassWithOfMethod.java
+++ b/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/AddExtensionAsBeanClassWithOfMethod.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit4.bean.extension;
+
+import org.jboss.weld.inject.WeldInstance;
+import org.jboss.weld.junit4.WeldInitiator;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class AddExtensionAsBeanClassWithOfMethod {
+
+    @Rule
+    public WeldInitiator weld = WeldInitiator.of(GoodOldBean.class, MyExtension.class);
+
+    @Test
+    public void testThatClassIsRecognizedAsExtension() {
+        // GoodOldBean should be resolvable
+        Assert.assertTrue(weld.select(GoodOldBean.class).isResolvable());
+        WeldInstance<MyExtension> extInstance = weld.select(MyExtension.class);
+        // extension should be resolvable and should have observed the other bean
+        Assert.assertTrue(extInstance.isResolvable());
+        Assert.assertTrue(extInstance.get().beanObserved());
+    }
+}

--- a/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/GoodOldBean.java
+++ b/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/GoodOldBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit4.bean.extension;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class GoodOldBean {
+
+}

--- a/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/MyExtension.java
+++ b/junit4/src/test/java/org/jboss/weld/junit4/bean/extension/MyExtension.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit4.bean.extension;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class MyExtension implements Extension {
+
+    private boolean beanObserved = false;
+
+    public void observePAT(@Observes ProcessAnnotatedType<GoodOldBean> event) {
+        beanObserved = true;
+    }
+    
+    public boolean beanObserved() {
+        return beanObserved;
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/AddExtensionAsBeanClassWithFromMethodTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/AddExtensionAsBeanClassWithFromMethodTest.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean.extension;
+
+import org.jboss.weld.inject.WeldInstance;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@EnableWeld
+public class AddExtensionAsBeanClassWithFromMethodTest {
+
+    @WeldSetup
+    WeldInitiator weld = WeldInitiator.from(GoodOldBean.class, MyExtension.class).build();
+
+    @Test
+    public void testThatClassIsRecognizedAsExtension() {
+        // GoodOldBean should be resolvable
+        Assertions.assertTrue(weld.select(GoodOldBean.class).isResolvable());
+        WeldInstance<MyExtension> extInstance = weld.select(MyExtension.class);
+        // extension should be resolvable and should have observed the other bean
+        Assertions.assertTrue(extInstance.isResolvable());
+        Assertions.assertTrue(extInstance.get().beanObserved());
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/AddExtensionAsBeanClassWithOfMethodTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/AddExtensionAsBeanClassWithOfMethodTest.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean.extension;
+
+import org.jboss.weld.inject.WeldInstance;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@EnableWeld
+public class AddExtensionAsBeanClassWithOfMethodTest {
+
+    @WeldSetup
+    WeldInitiator weld = WeldInitiator.of(GoodOldBean.class, MyExtension.class);
+
+    @Test
+    public void testThatClassIsRecognizedAsExtension() {
+        // GoodOldBean should be resolvable
+        Assertions.assertTrue(weld.select(GoodOldBean.class).isResolvable());
+        WeldInstance<MyExtension> extInstance = weld.select(MyExtension.class);
+        // extension should be resolvable and should have observed the other bean
+        Assertions.assertTrue(extInstance.isResolvable());
+        Assertions.assertTrue(extInstance.get().beanObserved());
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/GoodOldBean.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/GoodOldBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean.extension;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class GoodOldBean {
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/MyExtension.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/bean/extension/MyExtension.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.junit5.bean.extension;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class MyExtension implements Extension {
+
+    private boolean beanObserved = false;
+
+    public void observePAT(@Observes ProcessAnnotatedType<GoodOldBean> event) {
+        beanObserved = true;
+    }
+    
+    public boolean beanObserved() {
+        return beanObserved;
+    }
+}


### PR DESCRIPTION
…well.

Resolves #31 

Both methods - `of()` and `from()` - support extensions now.
I am not sure whether some other methods should support this as well? (such as `fromTestPackage()`)