### PR TITLE
@OverrideBean should not be applicable to Type.

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/auto/OverrideBean.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/auto/OverrideBean.java
@@ -53,6 +53,6 @@ import java.lang.annotation.Target;
 @Stereotype
 @Alternative
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.FIELD, ElementType.METHOD})
 public @interface OverrideBean {
 }


### PR DESCRIPTION
The ability to target types was incidental and doesn't make sense.
Removing to prevent confusion.