### PR TITLE
Weld container should not startup for @Disabled methods

### DIFF
--- a/junit-common/src/main/java/org/jboss/weld/junit/MockEjbInjectionServices.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/MockEjbInjectionServices.java
@@ -53,7 +53,7 @@ public class MockEjbInjectionServices implements EjbInjectionServices {
         };
     }
 
-    @Override
+    // only for Weld 2
     public Object resolveEjb(InjectionPoint injectionPoint) {
         return ejbFactory.apply(injectionPoint);
     }

--- a/junit-common/src/main/java/org/jboss/weld/junit/MockJpaInjectionServices.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/MockJpaInjectionServices.java
@@ -64,7 +64,7 @@ public class MockJpaInjectionServices implements JpaInjectionServices {
         };
     }
 
-    @Override
+    // only for Weld 2
     public EntityManager resolvePersistenceContext(InjectionPoint injectionPoint) {
         if (persistenceContextFactory == null) {
             throw new IllegalStateException("Persistent context factory not set, cannot resolve injection point: " + injectionPoint);
@@ -76,7 +76,7 @@ public class MockJpaInjectionServices implements JpaInjectionServices {
         throw new IllegalStateException("Not an EntityManager instance: " + context);
     }
 
-    @Override
+    // only for Weld 2
     public EntityManagerFactory resolvePersistenceUnit(InjectionPoint injectionPoint) {
         if (persistenceUnitFactory == null) {
             throw new IllegalStateException("Persistent unit factory not set, cannot resolve injection point: " + injectionPoint);

--- a/junit-common/src/main/java/org/jboss/weld/junit/MockResourceInjectionServices.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/MockResourceInjectionServices.java
@@ -49,7 +49,7 @@ public class MockResourceInjectionServices implements ResourceInjectionServices 
         this.resources = ImmutableMap.copyOf(resources);
     }
 
-    @Override
+    // only for Weld 2
     public Object resolveResource(InjectionPoint injectionPoint) {
         Resource resource = getResourceAnnotation(injectionPoint);
         if (resource == null) {
@@ -83,7 +83,7 @@ public class MockResourceInjectionServices implements ResourceInjectionServices 
         throw new UnsupportedOperationException();
     }
 
-    @Override
+    // only for Weld 2
     public Object resolveResource(String jndiName, String mappedName) {
         throw new UnsupportedOperationException();
     }

--- a/junit4/pom.xml
+++ b/junit4/pom.xml
@@ -45,22 +45,6 @@
 
    </dependencies>
 
-   <build>
-      <plugins>
-         <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-               <systemProperties>
-                  <property>
-                     <name>java.util.logging.config.file</name>
-                     <value>${project.build.testOutputDirectory}/logging.properties</value>
-                  </property>
-               </systemProperties>
-            </configuration>
-         </plugin>
-      </plugins>
-   </build>
-
    <profiles>
 
       <profile>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -48,36 +48,8 @@
          <artifactId>hibernate-jpa-2.1-api</artifactId>
          <scope>test</scope>
       </dependency>
-
+      
    </dependencies>
-
-   <build>
-      <pluginManagement>
-         <plugins>
-            <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-surefire-plugin</artifactId>
-               <dependencies>
-                  <!-- Surefire doesn't know JUnit 5 provider yet, we need
-                     to add it here -->
-                  <dependency>
-                     <groupId>org.junit.platform</groupId>
-                     <artifactId>junit-platform-surefire-provider</artifactId>
-                     <version>${version.junit.platform}</version>
-                  </dependency>
-               </dependencies>
-               <configuration>
-                  <systemProperties>
-                     <property>
-                        <name>java.util.logging.config.file</name>
-                        <value>${project.build.testOutputDirectory}/logging.properties</value>
-                     </property>
-                  </systemProperties>
-               </configuration>
-            </plugin>
-         </plugins>
-      </pluginManagement>
-   </build>
 
    <profiles>
 

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/DisabledMethodsTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/DisabledMethodsTest.java
@@ -1,0 +1,55 @@
+package org.jboss.weld.junit5.basic;
+
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that disabled methods do not trigger Weld container startup.
+ * For this test to work, @TestMethodOrder is required.
+ * Failure of this test might cause failures of other tests because of multiple active containers!
+ *
+ * @author Matej Novotny
+ */
+@ExtendWith(WeldJunit5Extension.class)
+@TestMethodOrder(value = MethodOrderer.Alphanumeric.class) // enforces ordering of methods, required!
+public class DisabledMethodsTest {
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+    @BeforeEach
+    public void tryUseWeldInBeforeEach() {
+        assertTrue(weld.isRunning());
+        assertTrue(weld.select(Foo.class).isResolvable());
+    }
+
+    @AfterEach
+    public void tryUseWeldAfterEachMethod() {
+        assertTrue(weld.isRunning());
+        assertTrue(weld.select(Foo.class).isResolvable());
+    }
+
+    @Test
+    @Disabled
+    public void executedFirst() {
+        // dummy disabled test method
+    }
+
+    @Test
+    public void testRunningContainers() {
+        // we assert that there is only one container running at this point
+        assertEquals(1, WeldContainer.getRunningContainerIds().size());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,10 @@
       <maven.compiler.target>1.8</maven.compiler.target>
       <!-- Versions -->
       <version.junit4>4.12</version.junit4>
-      <version.junit.platform>1.1.0</version.junit.platform>
-      <version.junit.jupiter>5.1.0</version.junit.jupiter>
+      <version.junit.jupiter>5.4.1</version.junit.jupiter>
       <version.weld>2.4.8.Final</version.weld>
-      <version.weld3>3.0.5.Final</version.weld3>
-      <version.mockito>2.7.19</version.mockito>
+      <version.weld3>3.1.0.Final</version.weld3>
+      <version.mockito>2.25.1</version.mockito>
       <version.jboss-ejb-api>1.0.0.Final</version.jboss-ejb-api>
       <version.hibernate-jpa-api>1.0.0.Final</version.hibernate-jpa-api>
       <!-- SpotBugs properties -->
@@ -173,5 +172,26 @@
            </build>
        </profile>
    </profiles>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <!--Minimal version with Junit 5 engine support-->
+                    <version>2.22.1</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>java.util.logging.config.file</name>
+                                <value>${project.build.testOutputDirectory}/logging.properties</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>


### PR DESCRIPTION
After quite some time digging I found no reasonable way to detect that we are post-processing test instance for a disabled method.

Instead, I decided to rework the extension a bit and drop `TestInstancePostProcessor` altogether.
We now start/stop Weld container during `[Before|After]EachCallback` or `[Before|After]AllCallback` depending on test lifecycle (per method versus per class).

This passes all tests for me, however I am aware that this solution is far from ideal as `TestInstancePostProcessor` phase is meant to be used exactly what we used it for. I am unsure how this can affect user-defined before/after methods in tests - in the one I added it all works and extension preceeds the interceptor on method but I found no guarantee on this in JUnit docs.

I also added a commit that bumps some versions in POMs.