### PR TITLE
Correct javadoc errors, update weld-parent version.

### DIFF
--- a/junit-common/src/main/java/org/jboss/weld/junit/MockBean.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/MockBean.java
@@ -53,13 +53,13 @@ import org.jboss.weld.util.reflection.HierarchyDiscovery;
  * This custom {@link Bean} implementation is useful for mocking.
  * <p>
  * A new instance is usually created through a {@link Builder} (see also {@link #builder()}) and then passed to the
- * {@link WeldInitiator.Builder#addBeans(Bean...)} method.
+ * {@code WeldInitiator.Builder#addBeans(Bean...)} method.
  * </p>
  *
  * @author Martin Kouba
  *
  * @param <T>
- * @see WeldInitiator.Builder#addBean(Bean)
+ * See also {@code WeldInitiator.Builder#addBean(Bean)} method.
  * @since 1.1
  */
 public class MockBean<T> implements Bean<T>, PassivationCapable {
@@ -654,7 +654,6 @@ public class MockBean<T> implements Bean<T>, PassivationCapable {
          *
          * @param instance
          * @param creationalContext
-         * @return a new bean instance
          */
         void destroy(T instance, CreationalContext<T> creationalContext);
 

--- a/junit-common/src/main/java/org/jboss/weld/junit/MockInterceptor.java
+++ b/junit-common/src/main/java/org/jboss/weld/junit/MockInterceptor.java
@@ -42,7 +42,7 @@ import org.jboss.weld.util.bean.SerializableForwardingBean;
  * This custom {@link Interceptor} implementation is useful for mocking.
  * <p>
  * A new instance is usually created through a {@link Builder} (see also {@link #withBindings(Annotation...)} method) and then passed to the
- * {@link WeldInitiator.Builder#addBeans(Bean...)} method.
+ * {@code WeldInitiator.Builder#addBeans(Bean...)} method.
  * </p>
  * <p>
  * Note that by default all mock interceptors are automatically enabled for the synthetic bean archive. If needed a custom bean class can be set through the
@@ -51,7 +51,7 @@ import org.jboss.weld.util.bean.SerializableForwardingBean;
  * </p>
  *
  * @author Martin Kouba
- * @see WeldInitiator.Builder#addBean(Bean)
+ * See also {code WeldInitiator.Builder#addBean(Bean)} method.
  * @since 1.2.1
  */
 public class MockInterceptor implements Interceptor<MockInterceptorInstance> {
@@ -250,7 +250,7 @@ public class MockInterceptor implements Interceptor<MockInterceptorInstance> {
 
         /**
          *
-         * @param function The interception callback, intercepted bean might be <code>null</code>
+         * @param callback The interception callback, intercepted bean might be <code>null</code>
          * @return self
          */
         public Builder callback(InterceptionCallback callback) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
    <parent>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-parent</artifactId>
-      <version>37</version>
+      <version>42</version>
    </parent>
 
    <url>http://weld.cdi-spec.org</url>
@@ -179,5 +179,18 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <!-- Needed to download org.apache.maven.plugins:maven-compiler-plugin:jar -->
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>


### PR DESCRIPTION
During the release I stumbled on issues while building javadoc with JDK 11.
Here are some fixes for it plus an update to weld-parent which has plugin config for javadocs.