### PR TITLE
Introduce recursive search for WeldInitiator in nested test classes

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -2,7 +2,7 @@ name: Weld-JUnit CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ 3.0 ]
 
 jobs:
   build-weld-junit:

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -21,6 +21,8 @@ Requirements are JUnit 5 and Java 8.
       * [Adding mock beans](#adding-mock-beans)
       * [Adding mock interceptors](#adding-mock-interceptors)
       * [Mock injection services](#mock-injection-services)
+    * [Inheritance](#inheritance-of-test-classes)
+    * [Nested test classes](#nested-test-classes)
 * [WeldJunit5AutoExtension](#weldjunit5autoextension)
   * [`@ActivateScopes`](#activatescopes)
   * [`@AddBeanClasses`](#addbeanclasses)
@@ -380,6 +382,103 @@ class MyTest {
     public void test(Baz baz) {
        Assertions.assertEquals("coolString", baz.coolResource);
     }
+}
+```
+
+#### Inheritance of test classes
+
+The `@WeldSetup` field can be defined in a superclass, but there can only be one `@WeldSetup` field in the class
+hierarchy.
+
+```java
+abstract class GenericTest {
+  @WeldSetup
+  protected WeldInitiator weldInitiator = WeldInitiator.of(Foo.class);
+}
+
+@EnableWeld
+class SpecializedTest extends GenericTest {
+
+  @Inject
+  Foo foo; // injected by the inherited Weld container
+
+  // This would throw an exception, because there would be two @WeldSetup fields in the class hierarchy
+  //
+  // @WeldSetup
+  // WeldInitiator secondWeldInitiator = WeldInitiator.of(Foo.class, Bar.class);
+}
+```
+
+#### Nested test classes
+
+A `@Nested` test class can have its own `WeldInitiator` field to configure a Weld container for the test methods of the
+nested class. If there is no `WeldInitiator` field in the class hierarchy of the nested class, the enclosing class (and
+its class hierarchy) is queried for *its* `WeldInitiator`
+field and so on until the outermost test class is reached.
+
+```java
+
+@EnableWeld
+class OuterTest {
+
+  @WeldSetup
+  WeldInitiator weld = WeldInitiator.of(Foo.class);
+
+  @Test
+  void test(Foo myFoo) {
+    assertNotNull(myFoo);
+    assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+  }
+
+  @Nested
+  class InnerTestWithoutItsOwnInitiator {
+
+    @Test
+    void testInnerMethodWithOuterWeldContainer(Foo myFoo) {
+      assertNotNull(myFoo);
+    }
+  }
+
+  @Nested
+  class InnerTestWithItsOwnInitiator {
+
+    @WeldSetup
+    WeldInitiator weld = WeldInitiator.of(Foo.class, Bar.class);
+
+    @Test
+    void testInnerMethodWithInnerWeldContainer(Foo myFoo, Bar myBar) {
+      assertNotNull(myFoo);
+      assertNotNull(myBar);
+    }
+  }
+}
+```
+
+**Attention**: There is only one Weld container for every test so no matter if the inner or the outer `WeldInitiator` field is chosen to initialize that container, it is used to fill the injection points in the nested class *and* its enclosing class(es). Therefore, you have to make sure that all beans that the outer class(es) requires are also present in the inner `WeldInitiator`!
+
+```java
+class OuterTest {
+
+  @WeldSetup
+  WeldInitiator outerWeld = WeldInitiator.of(Foo.class);
+
+  @Inject
+  Foo foo;
+
+  @Nested
+  class InnerTest {
+
+    @WeldSetup
+    WeldInitiator innerWeld = WeldInitiator.of(Bar.class);
+
+    // This test fails with an exception, because OuterTest.this.foo
+    // cannot be injected by the inner Weld container.
+    //
+    // @Test
+    // void testAnything() {
+    //   Assertions.assertTrue(true);
+    // }
+  }
 }
 ```
 

--- a/junit5/src/test/java/org/jboss/weld/junit5/initiator/bean/Bar.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/initiator/bean/Bar.java
@@ -1,0 +1,3 @@
+package org.jboss.weld.junit5.initiator.bean;
+
+public class Bar {}

--- a/junit5/src/test/java/org/jboss/weld/junit5/initiator/discovery/NestedClassesWeldInitiatorTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/initiator/discovery/NestedClassesWeldInitiatorTest.java
@@ -1,0 +1,119 @@
+package org.jboss.weld.junit5.initiator.discovery;
+
+import jakarta.inject.Inject;
+import org.jboss.weld.exceptions.UnsatisfiedResolutionException;
+import org.jboss.weld.junit5.EnableWeld;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldSetup;
+import org.jboss.weld.junit5.initiator.bean.Bar;
+import org.jboss.weld.junit5.initiator.bean.Foo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@EnableWeld
+public class NestedClassesWeldInitiatorTest {
+
+    @WeldSetup
+    private WeldInitiator outerWeld = WeldInitiator.of(Foo.class);
+
+    @Inject
+    Foo outerFoo;
+
+    @Test
+    void testWeldWorksInOuterClass() {
+        Assertions.assertNotNull(outerFoo);
+        Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+    }
+
+    @Nested
+    class NestedWithoutInitiatorTest {
+
+        @Inject
+        Foo innerFoo;
+
+        @Test
+        void testWeldWorksInInnerClass() {
+            Assertions.assertNotNull(outerFoo);
+            Assertions.assertNotNull(innerFoo);
+            Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+        }
+
+        @Nested
+        class TwiceNestedWithoutInitiatorTest {
+
+            @Inject
+            Foo innerInnerFoo;
+
+            @Test
+            void testWeldWorksInSecondInnerClass() {
+                Assertions.assertNotNull(outerFoo);
+                Assertions.assertNotNull(innerFoo);
+                Assertions.assertNotNull(innerInnerFoo);
+                Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> outerWeld.select(Bar.class).get());
+            }
+        }
+    }
+
+    @Nested
+    class NestedWithInitiatorTest {
+
+        @WeldSetup
+        private WeldInitiator innerWeld = WeldInitiator.of(Foo.class, Bar.class);
+
+        @Inject
+        Foo innerFoo;
+
+        @Inject
+        Bar bar;
+
+        @Test
+        void testWeldWorksInInnerClass() {
+            Assertions.assertNotNull(outerFoo);
+            Assertions.assertNotNull(bar);
+
+            // verify outer weld container is not running
+            Assertions.assertThrows(IllegalStateException.class, () -> outerWeld.select(Foo.class));
+        }
+
+        @Nested
+        class TwiceNestedWithoutInitiatorTest {
+
+            @Inject
+            Foo innerInnerFoo;
+
+            @Inject
+            Bar innerBar;
+
+            @Test
+            void testWeldWorksInSecondInnerClass() {
+                Assertions.assertNotNull(outerFoo);
+                Assertions.assertNotNull(innerFoo);
+                Assertions.assertNotNull(innerInnerFoo);
+
+                Assertions.assertNotNull(bar);
+                Assertions.assertNotNull(innerBar);
+
+                // verify outer weld container is not running
+                Assertions.assertThrows(IllegalStateException.class, () -> outerWeld.select(Foo.class));
+            }
+        }
+    }
+
+    @Nested
+    class NestedWithInheritedWeldInitiatorTest extends SuperclassWithProtectedWeldInitiator {
+
+        @Inject
+        Foo innerFoo;
+
+        @Test
+        void testInheritedTakesPrecedenceOverEnclosingWeldInitiator() {
+            Assertions.assertNotNull(outerFoo);
+            Assertions.assertNotNull(innerFoo);
+            Assertions.assertThrows(UnsatisfiedResolutionException.class, () -> weld.select(Bar.class).get());
+
+            // verify outer weld container is not running
+            Assertions.assertThrows(IllegalStateException.class, () -> outerWeld.select(Foo.class));
+        }
+    }
+}


### PR DESCRIPTION
* add recursive search for WeldInitiator in nested test classes
* clarify the behaviour for class hierarchies and nested tests
* add unit test for nested classes that inherit a WeldInitiator

3.x backport of #129 